### PR TITLE
Remove sentence from docstring

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1307,8 +1307,6 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         If an array, the features are mapped to constraints by position. See
         :ref:`monotonic_cst_features_names` for a usage example.
 
-        The constraints are only valid for binary classifications and hold
-        over the probability of the positive class.
         Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes 27737

#### What does this implement/fix? Explain your changes.
Removes a sentence from HistGBM Regressor. The sentence describes the validity of `monotonic_cst` argument when used with HistGBM classifier. As it appears in the docstring of the Regressor, it could be read as suggesting the feature is not valid or not implemented for Regression.